### PR TITLE
Added event_name right-hand label, label now displays

### DIFF
--- a/classes/service_form.php
+++ b/classes/service_form.php
@@ -91,7 +91,7 @@ class service_edit_form extends moodleform {
 
         /* Formation of the list of elements */
         foreach ($eventlist as $event) {
-            $events[$event["component"]][] =& $mform->createElement("checkbox", $event["eventname"], $event["eventname"]);
+            $events[$event["component"]][] =& $mform->createElement("checkbox", $event["eventname"], $event["eventname"], $event["eventname"]);
         }
 
         /* Displays groups of items */


### PR DESCRIPTION
From https://docs.moodle.org/dev/lib/formslib.php_Form_Definition#checkbox: "The third parameter for this element is the label to display on the left side of the form. You can also supply a string as a fourth parameter to specify a label that will appear on the right of the element.".